### PR TITLE
UCAPI-135 404 response body empty

### DIFF
--- a/bruno/204 Requests/Insert/Valid UC Unexpected Params.bru
+++ b/bruno/204 Requests/Insert/Valid UC Unexpected Params.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "{{nino}}",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Insert",
     "dateOfBirth": "2002-04-27",
     "liabilityStartDate": "2025-08-19",

--- a/bruno/204 Requests/Insert/Valid UC.bru
+++ b/bruno/204 Requests/Insert/Valid UC.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "{{nino}}",
-    "universalCreditRecordType": "UC",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Insert",
     "dateOfBirth": "2002-04-27",
     "liabilityStartDate": "2025-08-19"

--- a/bruno/204 Requests/Terminate/Unexpected Parameters.bru
+++ b/bruno/204 Requests/Terminate/Unexpected Parameters.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "{{nino}}",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Terminate",
     "liabilityStartDate": "2025-08-19",
     "liabilityEndDate": "2026-06-30",

--- a/bruno/400 Requests/Insert/Invalid CorrelationId.bru
+++ b/bruno/400 Requests/Insert/Invalid CorrelationId.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "{{nino}}",
-    "universalCreditRecordType": "UC",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Insert",
     "dateOfBirth": "2002-04-27",
     "liabilityStartDate": "2025-08-19"

--- a/bruno/400 Requests/Insert/Invalid Date of Birth.bru
+++ b/bruno/400 Requests/Insert/Invalid Date of Birth.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "{{nino}}",
-    "universalCreditRecordType": "LCW/LCWRA",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Insert",
     "dateOfBirth": "INVALID_DATE_OF_BIRTH",
     "liabilityStartDate": "2025-08-19"

--- a/bruno/400 Requests/Insert/Invalid Liability Start Date.bru
+++ b/bruno/400 Requests/Insert/Invalid Liability Start Date.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "{{nino}}",
-    "universalCreditRecordType": "LCW/LCWRA",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Insert",
     "dateOfBirth": "2002-04-27",
     "liabilityStartDate": "INVALID_LIABILITY_START_DATE"

--- a/bruno/400 Requests/Insert/Invalid National Insurance Number.bru
+++ b/bruno/400 Requests/Insert/Invalid National Insurance Number.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "{{invalidNino}}",
-    "universalCreditRecordType": "LCW/LCWRA",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Insert",
     "dateOfBirth": "2002-04-27",
     "liabilityStartDate": "2025-08-19"

--- a/bruno/400 Requests/Insert/Invalid Universal Credit Action.bru
+++ b/bruno/400 Requests/Insert/Invalid Universal Credit Action.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "{{nino}}",
-    "universalCreditRecordType": "LCW/LCWRA",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "INVALID_UNIVERSAL_CREDIT_ACTION",
     "dateOfBirth": "2002-04-27",
     "liabilityStartDate": "2025-08-19"

--- a/bruno/400 Requests/Insert/Missing CorrelationId.bru
+++ b/bruno/400 Requests/Insert/Missing CorrelationId.bru
@@ -22,7 +22,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "{{nino}}",
-    "universalCreditRecordType": "UC",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Insert",
     "dateOfBirth": "2002-04-27",
     "liabilityStartDate": "2025-08-19"

--- a/bruno/400 Requests/Insert/Missing Date of Birth.bru
+++ b/bruno/400 Requests/Insert/Missing Date of Birth.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "{{nino}}",
-    "universalCreditRecordType": "LCW/LCWRA",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Insert",
     "liabilityStartDate": "2025-08-19"
   }

--- a/bruno/400 Requests/Insert/Missing Liability Start Date.bru
+++ b/bruno/400 Requests/Insert/Missing Liability Start Date.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "{{nino}}",
-    "universalCreditRecordType": "LCW/LCWRA",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Insert",
     "dateOfBirth": "2002-04-27"
   }

--- a/bruno/400 Requests/Insert/Missing National Insurance Number.bru
+++ b/bruno/400 Requests/Insert/Missing National Insurance Number.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "universalCreditRecordType": "LCW/LCWRA",
-    "universalCreditAction": "Insert",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "dateOfBirth": "2002-04-27",
     "liabilityStartDate": "2009-08-19"
   }

--- a/bruno/400 Requests/Insert/Missing National Insurance Number.bru
+++ b/bruno/400 Requests/Insert/Missing National Insurance Number.bru
@@ -22,8 +22,8 @@ headers {
 
 body:json {
   {
-    "universalCreditRecordType": "LCW/LCWRA",
     "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
+    "universalCreditAction": "Insert",
     "dateOfBirth": "2002-04-27",
     "liabilityStartDate": "2009-08-19"
   }

--- a/bruno/400 Requests/Insert/Missing Universal Credit Action.bru
+++ b/bruno/400 Requests/Insert/Missing Universal Credit Action.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "{{nino}}",
-    "universalCreditRecordType": "LCW/LCWRA",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "dateOfBirth": "2002-04-27",
     "liabilityStartDate": "2025-08-19"
   }

--- a/bruno/400 Requests/Terminate/Invalid CorrelationId.bru
+++ b/bruno/400 Requests/Terminate/Invalid CorrelationId.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "{{nino}}",
-    "universalCreditRecordType": "UC",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Terminate",
     "liabilityStartDate": "2025-08-19",
     "liabilityEndDate": "2026-06-30"

--- a/bruno/400 Requests/Terminate/Invalid Liability End date.bru
+++ b/bruno/400 Requests/Terminate/Invalid Liability End date.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "{{nino}}",
-    "universalCreditRecordType": "UC",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Terminate",
     "liabilityStartDate": "2025-08-19",
     "liabilityEndDate": "INVALID_LIABILITY_END_DATE"

--- a/bruno/400 Requests/Terminate/Invalid Liability Start date.bru
+++ b/bruno/400 Requests/Terminate/Invalid Liability Start date.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "{{nino}}",
-    "universalCreditRecordType": "UC",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Terminate",
     "liabilityStartDate": "INVALID_LIABILITY_START_DATE",
     "liabilityEndDate": "2026-06-30"

--- a/bruno/400 Requests/Terminate/Invalid National Insurance Number.bru
+++ b/bruno/400 Requests/Terminate/Invalid National Insurance Number.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "{{invalidNino}}",
-    "universalCreditRecordType": "UC",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Terminate",
     "liabilityStartDate": "2025-08-19",
     "liabilityEndDate": "2026-06-30"

--- a/bruno/400 Requests/Terminate/Invalid Universal Credit Action.bru
+++ b/bruno/400 Requests/Terminate/Invalid Universal Credit Action.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "{{nino}}",
-    "universalCreditRecordType": "UC",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "INVALID_UNIVERSAL_CREDIT_ACTION",
     "liabilityStartDate": "2025-08-19",
     "liabilityEndDate": "2026-06-30"

--- a/bruno/400 Requests/Terminate/Missing CorrelationId.bru
+++ b/bruno/400 Requests/Terminate/Missing CorrelationId.bru
@@ -22,7 +22,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "{{nino}}",
-    "universalCreditRecordType": "UC",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Terminate",
     "liabilityStartDate": "2025-08-19",
     "liabilityEndDate": "2026-06-30"

--- a/bruno/400 Requests/Terminate/Missing Liability End date.bru
+++ b/bruno/400 Requests/Terminate/Missing Liability End date.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "{{nino}}",
-    "universalCreditRecordType": "UC",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Terminate",
     "liabilityStartDate": "2025-08-19"
   }

--- a/bruno/400 Requests/Terminate/Missing Liability Start date.bru
+++ b/bruno/400 Requests/Terminate/Missing Liability Start date.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "{{nino}}",
-    "universalCreditRecordType": "UC",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Terminate",
     "liabilityEndDate": "2026-06-30"
   }

--- a/bruno/400 Requests/Terminate/Missing National Insurance Number.bru
+++ b/bruno/400 Requests/Terminate/Missing National Insurance Number.bru
@@ -22,7 +22,7 @@ headers {
 
 body:json {
   {
-    "universalCreditRecordType": "UC",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Terminate",
     "liabilityStartDate": "2025-08-19",
     "liabilityEndDate": "2026-06-30"

--- a/bruno/400 Requests/Terminate/Missing Universal Credit Action.bru
+++ b/bruno/400 Requests/Terminate/Missing Universal Credit Action.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "{{nino}}",
-    "universalCreditRecordType": "UC",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "liabilityStartDate": "2025-08-19",
     "liabilityEndDate": "2026-06-30"
   }

--- a/bruno/401 Requests/Insert/Invalid Token.bru
+++ b/bruno/401 Requests/Insert/Invalid Token.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "{{nino}}",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Insert",
     "dateOfBirth": "2002-04-27",
     "liabilityStartDate": "2025-08-19"

--- a/bruno/401 Requests/Insert/Invalid Token.bru
+++ b/bruno/401 Requests/Insert/Invalid Token.bru
@@ -1,7 +1,7 @@
 meta {
   name: Invalid Token
   type: http
-  seq: 2
+  seq: 1
   tags: [
     AUTH
   ]

--- a/bruno/401 Requests/Insert/Missing Auth Header.bru
+++ b/bruno/401 Requests/Insert/Missing Auth Header.bru
@@ -22,7 +22,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "{{nino}}",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Insert",
     "dateOfBirth": "2002-04-27",
     "liabilityStartDate": "2025-08-19"

--- a/bruno/401 Requests/Insert/Missing Auth Header.bru
+++ b/bruno/401 Requests/Insert/Missing Auth Header.bru
@@ -1,7 +1,7 @@
 meta {
   name: Missing Authorization Header
   type: http
-  seq: 1
+  seq: 2
   tags: [
     AUTH
   ]

--- a/bruno/401 Requests/Terminate/Invalid Token.bru
+++ b/bruno/401 Requests/Terminate/Invalid Token.bru
@@ -1,7 +1,7 @@
 meta {
   name: Invalid Token
   type: http
-  seq: 2
+  seq: 1
   tags: [
     AUTH
   ]

--- a/bruno/401 Requests/Terminate/Invalid Token.bru
+++ b/bruno/401 Requests/Terminate/Invalid Token.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "{{nino}}",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Terminate",
     "liabilityStartDate": "2025-08-19",
     "liabilityEndDate": "2026-06-30"

--- a/bruno/401 Requests/Terminate/Missing Auth Header.bru
+++ b/bruno/401 Requests/Terminate/Missing Auth Header.bru
@@ -22,7 +22,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "{{nino}}",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Terminate",
     "liabilityStartDate": "2025-08-19",
     "liabilityEndDate": "2026-06-30"

--- a/bruno/401 Requests/Terminate/Missing Auth Header.bru
+++ b/bruno/401 Requests/Terminate/Missing Auth Header.bru
@@ -1,7 +1,7 @@
 meta {
   name: Missing Authorization Header
   type: http
-  seq: 1
+  seq: 2
   tags: [
     AUTH
   ]

--- a/bruno/403 Requests/Insert/Non Matching GovUkOriginatorId.bru
+++ b/bruno/403 Requests/Insert/Non Matching GovUkOriginatorId.bru
@@ -20,7 +20,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "{{nino}}",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Insert",
     "dateOfBirth": "2002-04-27",
     "liabilityStartDate": "2025-08-19"

--- a/bruno/403 Requests/Insert/Non Matching GovUkOriginatorId.bru
+++ b/bruno/403 Requests/Insert/Non Matching GovUkOriginatorId.bru
@@ -14,13 +14,13 @@ headers {
   Authorization: {{authorization}}
   Content-Type: application/json
   correlationId: {{correlationId}}
-  gov-uk-originator-id: ID-NOT-MATCHING-THE-ONE-PROVIDED-BY-DWP
+  gov-uk-originator-id: DWP-UC-7
 }
 
 body:json {
   {
     "nationalInsuranceNumber": "{{nino}}",
-    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
+    "universalCreditRecordType": "{{universalCreditRecordType}}",
     "universalCreditAction": "Insert",
     "dateOfBirth": "2002-04-27",
     "liabilityStartDate": "2025-08-19"

--- a/bruno/403 Requests/Terminate/Non Matching GovUkOriginatorId.bru
+++ b/bruno/403 Requests/Terminate/Non Matching GovUkOriginatorId.bru
@@ -20,7 +20,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "{{nino}}",
-    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
+    "universalCreditRecordType": "{{universalCreditRecordType}}",
     "universalCreditAction": "Terminate",
     "liabilityStartDate": "2025-08-19",
     "liabilityEndDate": "2026-06-30"

--- a/bruno/403 Requests/Terminate/Non Matching GovUkOriginatorId.bru
+++ b/bruno/403 Requests/Terminate/Non Matching GovUkOriginatorId.bru
@@ -20,7 +20,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "{{nino}}",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Terminate",
     "liabilityStartDate": "2025-08-19",
     "liabilityEndDate": "2026-06-30"

--- a/bruno/404 Requests/Insert/Invalid Endpoint.bru
+++ b/bruno/404 Requests/Insert/Invalid Endpoint.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "{{nino}}",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Insert",
     "dateOfBirth": "2002-04-27",
     "liabilityStartDate": "2025-08-19"

--- a/bruno/404 Requests/Insert/NINO not Present on HIP.bru
+++ b/bruno/404 Requests/Insert/NINO not Present on HIP.bru
@@ -3,7 +3,7 @@ meta {
   type: http
   seq: 2
   tags: [
-    DOWNSTREAM
+    NOTFOUND
   ]
 }
 
@@ -30,18 +30,18 @@ body:json {
   }
 }
 
-script:pre-request {
-  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
-
-  if (ninoPrefix != "CM110") {
-    throw new Error('The nationalInsuranceNumber should start with "CM110" to trigger a 404.');
-  }
-}
-
 assert {
   res.status: eq 404
   res.headers.correlationid: eq {{correlationId}}
   res.body: isEmpty
+}
+
+script:pre-request {
+  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
+  
+  if (ninoPrefix != "CM110") {
+    throw new Error('The nationalInsuranceNumber should start with "CM110" to trigger a 404.');
+  }
 }
 
 docs {

--- a/bruno/404 Requests/Insert/NINO not Present on HIP.bru
+++ b/bruno/404 Requests/Insert/NINO not Present on HIP.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "CM110000",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Insert",
     "dateOfBirth": "2002-04-27",
     "liabilityStartDate": "2025-08-19"

--- a/bruno/404 Requests/Insert/Trigger HIP NotFound.bru
+++ b/bruno/404 Requests/Insert/Trigger HIP NotFound.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "XY404000",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Insert",
     "dateOfBirth": "2002-04-27",
     "liabilityStartDate": "2025-08-19"

--- a/bruno/404 Requests/Terminate/Invalid Endpoint.bru
+++ b/bruno/404 Requests/Terminate/Invalid Endpoint.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "{{nino}}",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Terminate",
     "liabilityStartDate": "2025-08-19",
     "liabilityEndDate": "2026-06-30"

--- a/bruno/404 Requests/Terminate/NINO not Present on HIP.bru
+++ b/bruno/404 Requests/Terminate/NINO not Present on HIP.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "CM110000",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Terminate",
     "liabilityStartDate": "2025-08-19",
     "liabilityEndDate": "2026-06-30"

--- a/bruno/404 Requests/Terminate/NINO not Present on HIP.bru
+++ b/bruno/404 Requests/Terminate/NINO not Present on HIP.bru
@@ -3,7 +3,7 @@ meta {
   type: http
   seq: 2
   tags: [
-    DOWNSTREAM
+    NOTFOUND
   ]
 }
 
@@ -30,24 +30,18 @@ body:json {
   }
 }
 
+assert {
+  res.status: eq 404
+  res.headers.correlationid: eq {{correlationId}}
+  res.body: isEmpty
+}
+
 script:pre-request {
   let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
-
+  
   if (ninoPrefix != "CM110") {
     throw new Error('The nationalInsuranceNumber should start with "CM110" to trigger a 404.');
   }
-}
-
-assert {
-  res.status: eq 404
-  res.headers.correlationid: eq {{correlationId}}
-  res.body: isEmpty
-}
-
-assert {
-  res.status: eq 404
-  res.headers.correlationid: eq {{correlationId}}
-  res.body: isEmpty
 }
 
 docs {

--- a/bruno/404 Requests/Terminate/Trigger HIP NotFound.bru
+++ b/bruno/404 Requests/Terminate/Trigger HIP NotFound.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "XY404000",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Terminate",
     "liabilityStartDate": "2025-08-19",
     "liabilityEndDate": "2026-06-30"

--- a/bruno/422 Requests/Insert/55006 - Start and End Date must be earlier than Date of Death.bru
+++ b/bruno/422 Requests/Insert/55006 - Start and End Date must be earlier than Date of Death.bru
@@ -30,18 +30,18 @@ body:json {
   }
 }
 
-script:pre-request {
-  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
-
-  if (ninoPrefix != "BW130") {
-    throw new Error('The nationalInsuranceNumber should start with "BW130" to trigger a 55006.');
-  }
-}
-
 assert {
   res.status: eq 422
   res.headers.correlationid: eq {{correlationId}}
   res.body: isJson
   res.body.code: eq '55006'
   res.body.message: eq 'Start Date and End Date must be earlier than Date of Death'
+}
+
+script:pre-request {
+  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
+  
+  if (ninoPrefix != "BW130") {
+    throw new Error('The nationalInsuranceNumber should start with "BW130" to trigger a 55006.');
+  }
 }

--- a/bruno/422 Requests/Insert/55006 - Start and End Date must be earlier than Date of Death.bru
+++ b/bruno/422 Requests/Insert/55006 - Start and End Date must be earlier than Date of Death.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "BW130000",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Insert",
     "dateOfBirth": "2002-04-27",
     "liabilityStartDate": "2025-08-19"

--- a/bruno/422 Requests/Insert/55008 - End Date earlier than State Pension Age.bru
+++ b/bruno/422 Requests/Insert/55008 - End Date earlier than State Pension Age.bru
@@ -30,18 +30,18 @@ body:json {
   }
 }
 
-script:pre-request {
-  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
-
-  if (ninoPrefix != "EZ200") {
-    throw new Error('The nationalInsuranceNumber should start with "EZ200" to trigger a 55008.');
-  }
-}
-
 assert {
   res.status: eq 422
   res.headers.correlationid: eq {{correlationId}}
   res.body: isJson
   res.body.code: eq '55008'
   res.body.message: eq 'End Date must be earlier than State Pension Age'
+}
+
+script:pre-request {
+  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
+  
+  if (ninoPrefix != "EZ200") {
+    throw new Error('The nationalInsuranceNumber should start with "EZ200" to trigger a 55008.');
+  }
 }

--- a/bruno/422 Requests/Insert/55008 - End Date earlier than State Pension Age.bru
+++ b/bruno/422 Requests/Insert/55008 - End Date earlier than State Pension Age.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "EZ200000",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Insert",
     "dateOfBirth": "2002-04-27",
     "liabilityStartDate": "2025-08-19"

--- a/bruno/422 Requests/Insert/55027 - End Date later than Date of Death.bru
+++ b/bruno/422 Requests/Insert/55027 - End Date later than Date of Death.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "BK190000",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Insert",
     "dateOfBirth": "2002-04-27",
     "liabilityStartDate": "2025-08-19"

--- a/bruno/422 Requests/Insert/55027 - End Date later than Date of Death.bru
+++ b/bruno/422 Requests/Insert/55027 - End Date later than Date of Death.bru
@@ -30,18 +30,18 @@ body:json {
   }
 }
 
-script:pre-request {
-  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
-
-  if (ninoPrefix != "BK190") {
-    throw new Error('The nationalInsuranceNumber should start with "BK190" to trigger a 55027.');
-  }
-}
-
 assert {
   res.status: eq 422
   res.headers.correlationid: eq {{correlationId}}
   res.body: isJson
   res.body.code: eq '55027'
   res.body.message: eq 'End Date later than Date of Death'
+}
+
+script:pre-request {
+  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
+  
+  if (ninoPrefix != "BK190") {
+    throw new Error('The nationalInsuranceNumber should start with "BK190" to trigger a 55027.');
+  }
 }

--- a/bruno/422 Requests/Insert/55029 - Start Date later than State Pension Age.bru
+++ b/bruno/422 Requests/Insert/55029 - Start Date later than State Pension Age.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "ET060000",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Insert",
     "dateOfBirth": "2002-04-27",
     "liabilityStartDate": "2025-08-19"

--- a/bruno/422 Requests/Insert/55029 - Start Date later than State Pension Age.bru
+++ b/bruno/422 Requests/Insert/55029 - Start Date later than State Pension Age.bru
@@ -30,18 +30,18 @@ body:json {
   }
 }
 
-script:pre-request {
-  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
-
-  if (ninoPrefix != "ET060") {
-    throw new Error('The nationalInsuranceNumber should start with "ET060" to trigger a 55029.');
-  }
-}
-
 assert {
   res.status: eq 422
   res.headers.correlationid: eq {{correlationId}}
   res.body: isJson
   res.body.code: eq '55029'
   res.body.message: eq 'Start Date later than SPA'
+}
+
+script:pre-request {
+  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
+  
+  if (ninoPrefix != "ET060") {
+    throw new Error('The nationalInsuranceNumber should start with "ET060" to trigger a 55029.');
+  }
 }

--- a/bruno/422 Requests/Insert/55038 - Conflicting or identical Liability already recorded.bru
+++ b/bruno/422 Requests/Insert/55038 - Conflicting or identical Liability already recorded.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "GE100000",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Insert",
     "dateOfBirth": "2002-04-27",
     "liabilityStartDate": "2025-08-19"

--- a/bruno/422 Requests/Insert/55038 - Conflicting or identical Liability already recorded.bru
+++ b/bruno/422 Requests/Insert/55038 - Conflicting or identical Liability already recorded.bru
@@ -30,18 +30,18 @@ body:json {
   }
 }
 
-script:pre-request {
-  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
-
-  if (ninoPrefix != "GE100") {
-    throw new Error('The nationalInsuranceNumber should start with "GE100" to trigger a 55038.');
-  }
-}
-
 assert {
   res.status: eq 422
   res.headers.correlationid: eq {{correlationId}}
   res.body: isJson
   res.body.code: eq '55038'
   res.body.message: eq 'A conflicting or identical Liability is already recorded'
+}
+
+script:pre-request {
+  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
+  
+  if (ninoPrefix != "GE100") {
+    throw new Error('The nationalInsuranceNumber should start with "GE100" to trigger a 55038.');
+  }
 }

--- a/bruno/422 Requests/Insert/55039 - No corresponding liability found.bru
+++ b/bruno/422 Requests/Insert/55039 - No corresponding liability found.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "GP050000",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Insert",
     "dateOfBirth": "2002-04-27",
     "liabilityStartDate": "2025-08-19"

--- a/bruno/422 Requests/Insert/55039 - No corresponding liability found.bru
+++ b/bruno/422 Requests/Insert/55039 - No corresponding liability found.bru
@@ -30,18 +30,18 @@ body:json {
   }
 }
 
-script:pre-request {
-  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
-
-  if (ninoPrefix != "GP050") {
-    throw new Error('The nationalInsuranceNumber should start with "GP050" to trigger a 55039.');
-  }
-}
-
 assert {
   res.status: eq 422
   res.headers.correlationid: eq {{correlationId}}
   res.body: isJson
   res.body.code: eq '55039'
   res.body.message: eq 'NO corresponding liability found'
+}
+
+script:pre-request {
+  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
+  
+  if (ninoPrefix != "GP050") {
+    throw new Error('The nationalInsuranceNumber should start with "GP050" to trigger a 55039.');
+  }
 }

--- a/bruno/422 Requests/Insert/64996 - Start Date not before date of death.bru
+++ b/bruno/422 Requests/Insert/64996 - Start Date not before date of death.bru
@@ -30,18 +30,18 @@ body:json {
   }
 }
 
-script:pre-request {
-  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
-
-  if (ninoPrefix != "EK310") {
-    throw new Error('The nationalInsuranceNumber should start with "EK310" to trigger a 64996.');
-  }
-}
-
 assert {
   res.status: eq 422
   res.headers.correlationid: eq {{correlationId}}
   res.body: isJson
   res.body.code: eq '64996'
   res.body.message: eq 'Start Date is not before date of death'
+}
+
+script:pre-request {
+  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
+  
+  if (ninoPrefix != "EK310") {
+    throw new Error('The nationalInsuranceNumber should start with "EK310" to trigger a 64996.');
+  }
 }

--- a/bruno/422 Requests/Insert/64996 - Start Date not before date of death.bru
+++ b/bruno/422 Requests/Insert/64996 - Start Date not before date of death.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "EK310000",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Insert",
     "dateOfBirth": "2002-04-27",
     "liabilityStartDate": "2025-08-19"

--- a/bruno/422 Requests/Insert/64997 - LCW-LCWRA not within UC period.bru
+++ b/bruno/422 Requests/Insert/64997 - LCW-LCWRA not within UC period.bru
@@ -30,18 +30,18 @@ body:json {
   }
 }
 
-script:pre-request {
-  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
-
-  if (ninoPrefix != "HS260") {
-    throw new Error('The nationalInsuranceNumber should start with "HS260" to trigger a 64997.');
-  }
-}
-
 assert {
   res.status: eq 422
   res.headers.correlationid: eq {{correlationId}}
   res.body: isJson
   res.body.code: eq '64997'
   res.body.message: eq 'LCW/LCWRA not within a period of UC'
+}
+
+script:pre-request {
+  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
+  
+  if (ninoPrefix != "HS260") {
+    throw new Error('The nationalInsuranceNumber should start with "HS260" to trigger a 64997.');
+  }
 }

--- a/bruno/422 Requests/Insert/64997 - LCW-LCWRA not within UC period.bru
+++ b/bruno/422 Requests/Insert/64997 - LCW-LCWRA not within UC period.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "HS260000",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Insert",
     "dateOfBirth": "2002-04-27",
     "liabilityStartDate": "2025-08-19"

--- a/bruno/422 Requests/Insert/64998 - LCW-LCWRA Override not within LCW-LCWRA period.bru
+++ b/bruno/422 Requests/Insert/64998 - LCW-LCWRA Override not within LCW-LCWRA period.bru
@@ -30,18 +30,18 @@ body:json {
   }
 }
 
-script:pre-request {
-  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
-
-  if (ninoPrefix != "CE150") {
-    throw new Error('The nationalInsuranceNumber should start with "CE150" to trigger a 64998.');
-  }
-}
-
 assert {
   res.status: eq 422
   res.headers.correlationid: eq {{correlationId}}
   res.body: isJson
   res.body.code: eq '64998'
   res.body.message: eq 'LCW/LCWRA Override not within a period of LCW/LCWRA'
+}
+
+script:pre-request {
+  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
+  
+  if (ninoPrefix != "CE150") {
+    throw new Error('The nationalInsuranceNumber should start with "CE150" to trigger a 64998.');
+  }
 }

--- a/bruno/422 Requests/Insert/64998 - LCW-LCWRA Override not within LCW-LCWRA period.bru
+++ b/bruno/422 Requests/Insert/64998 - LCW-LCWRA Override not within LCW-LCWRA period.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "CE150000",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Insert",
     "dateOfBirth": "2002-04-27",
     "liabilityStartDate": "2025-08-19"

--- a/bruno/422 Requests/Insert/65026 - Start date must not be before 16th birthday.bru
+++ b/bruno/422 Requests/Insert/65026 - Start date must not be before 16th birthday.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "HC210000",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Insert",
     "dateOfBirth": "2002-04-27",
     "liabilityStartDate": "2025-08-19"

--- a/bruno/422 Requests/Insert/65026 - Start date must not be before 16th birthday.bru
+++ b/bruno/422 Requests/Insert/65026 - Start date must not be before 16th birthday.bru
@@ -30,18 +30,18 @@ body:json {
   }
 }
 
-script:pre-request {
-  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
-
-  if (ninoPrefix != "HC210") {
-    throw new Error('The nationalInsuranceNumber should start with "HC210" to trigger a 65026.');
-  }
-}
-
 assert {
   res.status: eq 422
   res.headers.correlationid: eq {{correlationId}}
   res.body: isJson
   res.body.code: eq '65026'
   res.body.message: eq 'Start date must not be before 16th birthday'
+}
+
+script:pre-request {
+  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
+  
+  if (ninoPrefix != "HC210") {
+    throw new Error('The nationalInsuranceNumber should start with "HC210" to trigger a 65026.');
+  }
 }

--- a/bruno/422 Requests/Insert/65536 - Start date before 29-04-2013.bru
+++ b/bruno/422 Requests/Insert/65536 - Start date before 29-04-2013.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "GX240000",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Insert",
     "dateOfBirth": "2002-04-27",
     "liabilityStartDate": "2025-08-19"

--- a/bruno/422 Requests/Insert/65536 - Start date before 29-04-2013.bru
+++ b/bruno/422 Requests/Insert/65536 - Start date before 29-04-2013.bru
@@ -30,18 +30,18 @@ body:json {
   }
 }
 
-script:pre-request {
-  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
-
-  if (ninoPrefix != "GX240") {
-    throw new Error('The nationalInsuranceNumber should start with "GX240" to trigger a 65536.');
-  }
-}
-
 assert {
   res.status: eq 422
   res.headers.correlationid: eq {{correlationId}}
   res.body: isJson
   res.body.code: eq '65536'
   res.body.message: eq 'Start date before 29/04/2013'
+}
+
+script:pre-request {
+  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
+  
+  if (ninoPrefix != "GX240") {
+    throw new Error('The nationalInsuranceNumber should start with "GX240" to trigger a 65536.');
+  }
 }

--- a/bruno/422 Requests/Insert/65537 - End date before start date.bru
+++ b/bruno/422 Requests/Insert/65537 - End date before start date.bru
@@ -30,18 +30,18 @@ body:json {
   }
 }
 
-script:pre-request {
-  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
-
-  if (ninoPrefix != "HT230") {
-    throw new Error('The nationalInsuranceNumber should start with "HT230" to trigger a 65537.');
-  }
-}
-
 assert {
   res.status: eq 422
   res.headers.correlationid: eq {{correlationId}}
   res.body: isJson
   res.body.code: eq '65537'
   res.body.message: eq 'End date before start date'
+}
+
+script:pre-request {
+  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
+  
+  if (ninoPrefix != "HT230") {
+    throw new Error('The nationalInsuranceNumber should start with "HT230" to trigger a 65537.');
+  }
 }

--- a/bruno/422 Requests/Insert/65537 - End date before start date.bru
+++ b/bruno/422 Requests/Insert/65537 - End date before start date.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "HT230000",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Insert",
     "dateOfBirth": "2002-04-27",
     "liabilityStartDate": "2025-08-19"

--- a/bruno/422 Requests/Insert/65541 - NINO matches Pseudo Account.bru
+++ b/bruno/422 Requests/Insert/65541 - NINO matches Pseudo Account.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "BX100000",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Insert",
     "dateOfBirth": "2002-04-27",
     "liabilityStartDate": "2025-08-19"

--- a/bruno/422 Requests/Insert/65541 - NINO matches Pseudo Account.bru
+++ b/bruno/422 Requests/Insert/65541 - NINO matches Pseudo Account.bru
@@ -30,18 +30,18 @@ body:json {
   }
 }
 
-script:pre-request {
-  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
-
-  if (ninoPrefix != "BX100") {
-    throw new Error('The nationalInsuranceNumber should start with "BX100" to trigger a 65541.');
-  }
-}
-
 assert {
   res.status: eq 422
   res.headers.correlationid: eq {{correlationId}}
   res.body: isJson
   res.body.code: eq '65541'
   res.body.message: eq 'The NINO input matches a Pseudo Account'
+}
+
+script:pre-request {
+  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
+  
+  if (ninoPrefix != "BX100") {
+    throw new Error('The nationalInsuranceNumber should start with "BX100" to trigger a 65541.');
+  }
 }

--- a/bruno/422 Requests/Insert/65542 - NINO matches Non-Live Account.bru
+++ b/bruno/422 Requests/Insert/65542 - NINO matches Non-Live Account.bru
@@ -30,18 +30,18 @@ body:json {
   }
 }
 
-script:pre-request {
-  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
-
-  if (ninoPrefix != "HZ310") {
-    throw new Error('The nationalInsuranceNumber should start with "HZ310" to trigger a 65542.');
-  }
-}
-
 assert {
   res.status: eq 422
   res.headers.correlationid: eq {{correlationId}}
   res.body: isJson
   res.body.code: eq '65542'
   res.body.message: eq 'The NINO input matches a non-live account (including redundant, amalgamated and administrative account types)'
+}
+
+script:pre-request {
+  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
+  
+  if (ninoPrefix != "HZ310") {
+    throw new Error('The nationalInsuranceNumber should start with "HZ310" to trigger a 65542.');
+  }
 }

--- a/bruno/422 Requests/Insert/65542 - NINO matches Non-Live Account.bru
+++ b/bruno/422 Requests/Insert/65542 - NINO matches Non-Live Account.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "HZ310000",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Insert",
     "dateOfBirth": "2002-04-27",
     "liabilityStartDate": "2025-08-19"

--- a/bruno/422 Requests/Insert/65543 - Account Transferred Isle Of Man.bru
+++ b/bruno/422 Requests/Insert/65543 - Account Transferred Isle Of Man.bru
@@ -30,18 +30,18 @@ body:json {
   }
 }
 
-script:pre-request {
-  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
-
-  if (ninoPrefix != "BZ230") {
-    throw new Error('The nationalInsuranceNumber should start with "BZ230" to trigger a 65543.');
-  }
-}
-
 assert {
   res.status: eq 422
   res.headers.correlationid: eq {{correlationId}}
   res.body: isJson
   res.body.code: eq '65543'
   res.body.message: eq 'The NINO input matches an account that has been transferred to the Isle of Man'
+}
+
+script:pre-request {
+  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
+  
+  if (ninoPrefix != "BZ230") {
+    throw new Error('The nationalInsuranceNumber should start with "BZ230" to trigger a 65543.');
+  }
 }

--- a/bruno/422 Requests/Insert/65543 - Account Transferred Isle Of Man.bru
+++ b/bruno/422 Requests/Insert/65543 - Account Transferred Isle Of Man.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "BZ230000",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Insert",
     "dateOfBirth": "2002-04-27",
     "liabilityStartDate": "2025-08-19"

--- a/bruno/422 Requests/Insert/99999 - Start date after Death.bru
+++ b/bruno/422 Requests/Insert/99999 - Start date after Death.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "AB150000",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Insert",
     "dateOfBirth": "2002-04-27",
     "liabilityStartDate": "2025-08-19"

--- a/bruno/422 Requests/Insert/99999 - Start date after Death.bru
+++ b/bruno/422 Requests/Insert/99999 - Start date after Death.bru
@@ -30,18 +30,18 @@ body:json {
   }
 }
 
-script:pre-request {
-  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
-
-  if (ninoPrefix != "AB150") {
-    throw new Error('The nationalInsuranceNumber should start with "AB150" to trigger a 99999.');
-  }
-}
-
 assert {
   res.status: eq 422
   res.headers.correlationid: eq {{correlationId}}
   res.body: isJson
   res.body.code: eq '99999'
   res.body.message: eq 'Start Date after Death'
+}
+
+script:pre-request {
+  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
+  
+  if (ninoPrefix != "AB150") {
+    throw new Error('The nationalInsuranceNumber should start with "AB150" to trigger a 99999.');
+  }
 }

--- a/bruno/422 Requests/Terminate/55006 - Start and End Date must be earlier than Date of Death.bru
+++ b/bruno/422 Requests/Terminate/55006 - Start and End Date must be earlier than Date of Death.bru
@@ -30,18 +30,18 @@ body:json {
   }
 }
 
-script:pre-request {
-  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
-
-  if (ninoPrefix != "BW130") {
-    throw new Error('The nationalInsuranceNumber should start with "BW130" to trigger a 55006.');
-  }
-}
-
 assert {
   res.status: eq 422
   res.headers.correlationid: eq {{correlationId}}
   res.body: isJson
   res.body.code: eq '55006'
   res.body.message: eq 'Start Date and End Date must be earlier than Date of Death'
+}
+
+script:pre-request {
+  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
+  
+  if (ninoPrefix != "BW130") {
+    throw new Error('The nationalInsuranceNumber should start with "BW130" to trigger a 55006.');
+  }
 }

--- a/bruno/422 Requests/Terminate/55006 - Start and End Date must be earlier than Date of Death.bru
+++ b/bruno/422 Requests/Terminate/55006 - Start and End Date must be earlier than Date of Death.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "BW130000",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Terminate",
     "liabilityStartDate": "2025-08-19",
     "liabilityEndDate": "2026-06-30"

--- a/bruno/422 Requests/Terminate/55008 - End Date earlier than State Pension Age.bru
+++ b/bruno/422 Requests/Terminate/55008 - End Date earlier than State Pension Age.bru
@@ -30,18 +30,18 @@ body:json {
   }
 }
 
-script:pre-request {
-  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
-
-  if (ninoPrefix != "EZ200") {
-    throw new Error('The nationalInsuranceNumber should start with "EZ200" to trigger a 55008.');
-  }
-}
-
 assert {
   res.status: eq 422
   res.headers.correlationid: eq {{correlationId}}
   res.body: isJson
   res.body.code: eq '55008'
   res.body.message: eq 'End Date must be earlier than State Pension Age'
+}
+
+script:pre-request {
+  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
+  
+  if (ninoPrefix != "EZ200") {
+    throw new Error('The nationalInsuranceNumber should start with "EZ200" to trigger a 55008.');
+  }
 }

--- a/bruno/422 Requests/Terminate/55008 - End Date earlier than State Pension Age.bru
+++ b/bruno/422 Requests/Terminate/55008 - End Date earlier than State Pension Age.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "EZ200000",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Terminate",
     "liabilityStartDate": "2025-08-19",
     "liabilityEndDate": "2026-06-30"

--- a/bruno/422 Requests/Terminate/55027 - End Date later than Date of Death.bru
+++ b/bruno/422 Requests/Terminate/55027 - End Date later than Date of Death.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "BK190000",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Terminate",
     "liabilityStartDate": "2025-08-19",
     "liabilityEndDate": "2026-06-30"

--- a/bruno/422 Requests/Terminate/55027 - End Date later than Date of Death.bru
+++ b/bruno/422 Requests/Terminate/55027 - End Date later than Date of Death.bru
@@ -30,18 +30,18 @@ body:json {
   }
 }
 
-script:pre-request {
-  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
-
-  if (ninoPrefix != "BK190") {
-    throw new Error('The nationalInsuranceNumber should start with "BK190" to trigger a 55027.');
-  }
-}
-
 assert {
   res.status: eq 422
   res.headers.correlationid: eq {{correlationId}}
   res.body: isJson
   res.body.code: eq '55027'
   res.body.message: eq 'End Date later than Date of Death'
+}
+
+script:pre-request {
+  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
+  
+  if (ninoPrefix != "BK190") {
+    throw new Error('The nationalInsuranceNumber should start with "BK190" to trigger a 55027.');
+  }
 }

--- a/bruno/422 Requests/Terminate/55029 - Start Date later than State Pension Age.bru
+++ b/bruno/422 Requests/Terminate/55029 - Start Date later than State Pension Age.bru
@@ -30,18 +30,18 @@ body:json {
   }
 }
 
-script:pre-request {
-  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
-
-  if (ninoPrefix != "ET060") {
-    throw new Error('The nationalInsuranceNumber should start with "ET060" to trigger a 55029.');
-  }
-}
-
 assert {
   res.status: eq 422
   res.headers.correlationid: eq {{correlationId}}
   res.body: isJson
   res.body.code: eq '55029'
   res.body.message: eq 'Start Date later than SPA'
+}
+
+script:pre-request {
+  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
+  
+  if (ninoPrefix != "ET060") {
+    throw new Error('The nationalInsuranceNumber should start with "ET060" to trigger a 55029.');
+  }
 }

--- a/bruno/422 Requests/Terminate/55029 - Start Date later than State Pension Age.bru
+++ b/bruno/422 Requests/Terminate/55029 - Start Date later than State Pension Age.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "ET060000",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Terminate",
     "liabilityStartDate": "2025-08-19",
     "liabilityEndDate": "2026-06-30"

--- a/bruno/422 Requests/Terminate/55038 - Conflicting or identical Liability already recorded.bru
+++ b/bruno/422 Requests/Terminate/55038 - Conflicting or identical Liability already recorded.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "GE100000",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Terminate",
     "liabilityStartDate": "2025-08-19",
     "liabilityEndDate": "2026-06-30"

--- a/bruno/422 Requests/Terminate/55038 - Conflicting or identical Liability already recorded.bru
+++ b/bruno/422 Requests/Terminate/55038 - Conflicting or identical Liability already recorded.bru
@@ -30,18 +30,18 @@ body:json {
   }
 }
 
-script:pre-request {
-  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
-
-  if (ninoPrefix != "GE100") {
-    throw new Error('The nationalInsuranceNumber should start with "GE100" to trigger a 55038.');
-  }
-}
-
 assert {
   res.status: eq 422
   res.headers.correlationid: eq {{correlationId}}
   res.body: isJson
   res.body.code: eq '55038'
   res.body.message: eq 'A conflicting or identical Liability is already recorded'
+}
+
+script:pre-request {
+  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
+  
+  if (ninoPrefix != "GE100") {
+    throw new Error('The nationalInsuranceNumber should start with "GE100" to trigger a 55038.');
+  }
 }

--- a/bruno/422 Requests/Terminate/55039 - No corresponding liability found.bru
+++ b/bruno/422 Requests/Terminate/55039 - No corresponding liability found.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "GP050000",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Terminate",
     "liabilityStartDate": "2025-08-19",
     "liabilityEndDate": "2026-06-30"

--- a/bruno/422 Requests/Terminate/55039 - No corresponding liability found.bru
+++ b/bruno/422 Requests/Terminate/55039 - No corresponding liability found.bru
@@ -30,18 +30,18 @@ body:json {
   }
 }
 
-script:pre-request {
-  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
-
-  if (ninoPrefix != "GP050") {
-    throw new Error('The nationalInsuranceNumber should start with "GP050" to trigger a 55039.');
-  }
-}
-
 assert {
   res.status: eq 422
   res.headers.correlationid: eq {{correlationId}}
   res.body: isJson
   res.body.code: eq '55039'
   res.body.message: eq 'NO corresponding liability found'
+}
+
+script:pre-request {
+  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
+  
+  if (ninoPrefix != "GP050") {
+    throw new Error('The nationalInsuranceNumber should start with "GP050" to trigger a 55039.');
+  }
 }

--- a/bruno/422 Requests/Terminate/64996 - Start Date not before date of death.bru
+++ b/bruno/422 Requests/Terminate/64996 - Start Date not before date of death.bru
@@ -30,18 +30,18 @@ body:json {
   }
 }
 
-script:pre-request {
-  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
-
-  if (ninoPrefix != "EK310") {
-    throw new Error('The nationalInsuranceNumber should start with "EK310" to trigger a 64996.');
-  }
-}
-
 assert {
   res.status: eq 422
   res.headers.correlationid: eq {{correlationId}}
   res.body: isJson
   res.body.code: eq '64996'
   res.body.message: eq 'Start Date is not before date of death'
+}
+
+script:pre-request {
+  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
+  
+  if (ninoPrefix != "EK310") {
+    throw new Error('The nationalInsuranceNumber should start with "EK310" to trigger a 64996.');
+  }
 }

--- a/bruno/422 Requests/Terminate/64996 - Start Date not before date of death.bru
+++ b/bruno/422 Requests/Terminate/64996 - Start Date not before date of death.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "EK310000",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Terminate",
     "liabilityStartDate": "2025-08-19",
     "liabilityEndDate": "2026-06-30"

--- a/bruno/422 Requests/Terminate/64997 - LCW-LCWRA not within UC period.bru
+++ b/bruno/422 Requests/Terminate/64997 - LCW-LCWRA not within UC period.bru
@@ -30,18 +30,18 @@ body:json {
   }
 }
 
-script:pre-request {
-  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
-
-  if (ninoPrefix != "HS260") {
-    throw new Error('The nationalInsuranceNumber should start with "HS260" to trigger a 64997.');
-  }
-}
-
 assert {
   res.status: eq 422
   res.headers.correlationid: eq {{correlationId}}
   res.body: isJson
   res.body.code: eq '64997'
   res.body.message: eq 'LCW/LCWRA not within a period of UC'
+}
+
+script:pre-request {
+  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
+  
+  if (ninoPrefix != "HS260") {
+    throw new Error('The nationalInsuranceNumber should start with "HS260" to trigger a 64997.');
+  }
 }

--- a/bruno/422 Requests/Terminate/64997 - LCW-LCWRA not within UC period.bru
+++ b/bruno/422 Requests/Terminate/64997 - LCW-LCWRA not within UC period.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "HS260000",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Terminate",
     "liabilityStartDate": "2025-08-19",
     "liabilityEndDate": "2026-06-30"

--- a/bruno/422 Requests/Terminate/64998 - LCW-LCWRA Override not within LCW-LCWRA period.bru
+++ b/bruno/422 Requests/Terminate/64998 - LCW-LCWRA Override not within LCW-LCWRA period.bru
@@ -30,18 +30,18 @@ body:json {
   }
 }
 
-script:pre-request {
-  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
-
-  if (ninoPrefix != "CE150") {
-    throw new Error('The nationalInsuranceNumber should start with "CE150" to trigger a 64998.');
-  }
-}
-
 assert {
   res.status: eq 422
   res.headers.correlationid: eq {{correlationId}}
   res.body: isJson
   res.body.code: eq '64998'
   res.body.message: eq 'LCW/LCWRA Override not within a period of LCW/LCWRA'
+}
+
+script:pre-request {
+  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
+  
+  if (ninoPrefix != "CE150") {
+    throw new Error('The nationalInsuranceNumber should start with "CE150" to trigger a 64998.');
+  }
 }

--- a/bruno/422 Requests/Terminate/64998 - LCW-LCWRA Override not within LCW-LCWRA period.bru
+++ b/bruno/422 Requests/Terminate/64998 - LCW-LCWRA Override not within LCW-LCWRA period.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "CE150000",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Terminate",
     "liabilityStartDate": "2025-08-19",
     "liabilityEndDate": "2026-06-30"

--- a/bruno/422 Requests/Terminate/65026 - Start date must not be before 16th birthday.bru
+++ b/bruno/422 Requests/Terminate/65026 - Start date must not be before 16th birthday.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "HC210000",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Terminate",
     "liabilityStartDate": "2025-08-19",
     "liabilityEndDate": "2026-06-30"

--- a/bruno/422 Requests/Terminate/65026 - Start date must not be before 16th birthday.bru
+++ b/bruno/422 Requests/Terminate/65026 - Start date must not be before 16th birthday.bru
@@ -30,18 +30,18 @@ body:json {
   }
 }
 
-script:pre-request {
-  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
-
-  if (ninoPrefix != "HC210") {
-    throw new Error('The nationalInsuranceNumber should start with "HC210" to trigger a 65026.');
-  }
-}
-
 assert {
   res.status: eq 422
   res.headers.correlationid: eq {{correlationId}}
   res.body: isJson
   res.body.code: eq '65026'
   res.body.message: eq 'Start date must not be before 16th birthday'
+}
+
+script:pre-request {
+  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
+  
+  if (ninoPrefix != "HC210") {
+    throw new Error('The nationalInsuranceNumber should start with "HC210" to trigger a 65026.');
+  }
 }

--- a/bruno/422 Requests/Terminate/65536 - Start date before 29-04-2013.bru
+++ b/bruno/422 Requests/Terminate/65536 - Start date before 29-04-2013.bru
@@ -30,18 +30,18 @@ body:json {
   }
 }
 
-script:pre-request {
-  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
-
-  if (ninoPrefix != "GX240") {
-    throw new Error('The nationalInsuranceNumber should start with "GX240" to trigger a 65536.');
-  }
-}
-
 assert {
   res.status: eq 422
   res.headers.correlationid: eq {{correlationId}}
   res.body: isJson
   res.body.code: eq '65536'
   res.body.message: eq 'Start date before 29/04/2013'
+}
+
+script:pre-request {
+  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
+  
+  if (ninoPrefix != "GX240") {
+    throw new Error('The nationalInsuranceNumber should start with "GX240" to trigger a 65536.');
+  }
 }

--- a/bruno/422 Requests/Terminate/65536 - Start date before 29-04-2013.bru
+++ b/bruno/422 Requests/Terminate/65536 - Start date before 29-04-2013.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "GX240000",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Terminate",
     "liabilityStartDate": "2025-08-19",
     "liabilityEndDate": "2026-06-30"

--- a/bruno/422 Requests/Terminate/65537 - End date before start date.bru
+++ b/bruno/422 Requests/Terminate/65537 - End date before start date.bru
@@ -30,18 +30,18 @@ body:json {
   }
 }
 
-script:pre-request {
-  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
-
-  if (ninoPrefix != "HT230") {
-    throw new Error('The nationalInsuranceNumber should start with "HT230" to trigger a 65537.');
-  }
-}
-
 assert {
   res.status: eq 422
   res.headers.correlationid: eq {{correlationId}}
   res.body: isJson
   res.body.code: eq '65537'
   res.body.message: eq 'End date before start date'
+}
+
+script:pre-request {
+  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
+  
+  if (ninoPrefix != "HT230") {
+    throw new Error('The nationalInsuranceNumber should start with "HT230" to trigger a 65537.');
+  }
 }

--- a/bruno/422 Requests/Terminate/65537 - End date before start date.bru
+++ b/bruno/422 Requests/Terminate/65537 - End date before start date.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "HT230000",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Terminate",
     "liabilityStartDate": "2025-08-19",
     "liabilityEndDate": "2026-06-30"

--- a/bruno/422 Requests/Terminate/65541 - NINO matches Pseudo Account.bru
+++ b/bruno/422 Requests/Terminate/65541 - NINO matches Pseudo Account.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "BX100000",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Terminate",
     "liabilityStartDate": "2025-08-19",
     "liabilityEndDate": "2026-06-30"

--- a/bruno/422 Requests/Terminate/65541 - NINO matches Pseudo Account.bru
+++ b/bruno/422 Requests/Terminate/65541 - NINO matches Pseudo Account.bru
@@ -30,18 +30,18 @@ body:json {
   }
 }
 
-script:pre-request {
-  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
-
-  if (ninoPrefix != "BX100") {
-    throw new Error('The nationalInsuranceNumber should start with "BX100" to trigger a 65541.');
-  }
-}
-
 assert {
   res.status: eq 422
   res.headers.correlationid: eq {{correlationId}}
   res.body: isJson
   res.body.code: eq '65541'
   res.body.message: eq 'The NINO input matches a Pseudo Account'
+}
+
+script:pre-request {
+  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
+  
+  if (ninoPrefix != "BX100") {
+    throw new Error('The nationalInsuranceNumber should start with "BX100" to trigger a 65541.');
+  }
 }

--- a/bruno/422 Requests/Terminate/65542 - NINO matches Non-Live Account.bru
+++ b/bruno/422 Requests/Terminate/65542 - NINO matches Non-Live Account.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "HZ310000",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Terminate",
     "liabilityStartDate": "2025-08-19",
     "liabilityEndDate": "2026-06-30"

--- a/bruno/422 Requests/Terminate/65542 - NINO matches Non-Live Account.bru
+++ b/bruno/422 Requests/Terminate/65542 - NINO matches Non-Live Account.bru
@@ -30,18 +30,18 @@ body:json {
   }
 }
 
-script:pre-request {
-  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
-
-  if (ninoPrefix != "HZ310") {
-    throw new Error('The nationalInsuranceNumber should start with "HZ310" to trigger a 65542.');
-  }
-}
-
 assert {
   res.status: eq 422
   res.headers.correlationid: eq {{correlationId}}
   res.body: isJson
   res.body.code: eq '65542'
   res.body.message: eq 'The NINO input matches a non-live account (including redundant, amalgamated and administrative account types)'
+}
+
+script:pre-request {
+  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
+  
+  if (ninoPrefix != "HZ310") {
+    throw new Error('The nationalInsuranceNumber should start with "HZ310" to trigger a 65542.');
+  }
 }

--- a/bruno/422 Requests/Terminate/65543 - Account Transferred Isle of Man.bru
+++ b/bruno/422 Requests/Terminate/65543 - Account Transferred Isle of Man.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "BZ230000",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Terminate",
     "liabilityStartDate": "2025-08-19",
     "liabilityEndDate": "2026-06-30"

--- a/bruno/422 Requests/Terminate/65543 - Account Transferred Isle of Man.bru
+++ b/bruno/422 Requests/Terminate/65543 - Account Transferred Isle of Man.bru
@@ -30,18 +30,18 @@ body:json {
   }
 }
 
-script:pre-request {
-  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
-
-  if (ninoPrefix != "BZ230") {
-    throw new Error('The nationalInsuranceNumber should start with "BZ230" to trigger a 65543.');
-  }
-}
-
 assert {
   res.status: eq 422
   res.headers.correlationid: eq {{correlationId}}
   res.body: isJson
   res.body.code: eq '65543'
   res.body.message: eq 'The NINO input matches an account that has been transferred to the Isle of Man'
+}
+
+script:pre-request {
+  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
+  
+  if (ninoPrefix != "BZ230") {
+    throw new Error('The nationalInsuranceNumber should start with "BZ230" to trigger a 65543.');
+  }
 }

--- a/bruno/422 Requests/Terminate/99999 - Start Date after Death.bru
+++ b/bruno/422 Requests/Terminate/99999 - Start Date after Death.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "AB150000",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Terminate",
     "liabilityStartDate": "2025-08-19",
     "liabilityEndDate": "2026-06-30"

--- a/bruno/422 Requests/Terminate/99999 - Start Date after Death.bru
+++ b/bruno/422 Requests/Terminate/99999 - Start Date after Death.bru
@@ -30,18 +30,18 @@ body:json {
   }
 }
 
-script:pre-request {
-  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
-
-  if (ninoPrefix != "AB150") {
-    throw new Error('The nationalInsuranceNumber should start with "AB150" to trigger a 99999.');
-  }
-}
-
 assert {
   res.status: eq 422
   res.headers.correlationid: eq {{correlationId}}
   res.body: isJson
   res.body.code: eq '99999'
   res.body.message: eq 'Start Date after Death'
+}
+
+script:pre-request {
+  let ninoPrefix = req.body.nationalInsuranceNumber.substring(0, 5);
+  
+  if (ninoPrefix != "AB150") {
+    throw new Error('The nationalInsuranceNumber should start with "AB150" to trigger a 99999.');
+  }
 }

--- a/bruno/500 Requests/Insert/Trigger HIP BadRequest.bru
+++ b/bruno/500 Requests/Insert/Trigger HIP BadRequest.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "XY400000",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Insert",
     "dateOfBirth": "2002-04-27",
     "liabilityStartDate": "2025-08-19"

--- a/bruno/500 Requests/Insert/Trigger HIP Unauthorized.bru
+++ b/bruno/500 Requests/Insert/Trigger HIP Unauthorized.bru
@@ -24,7 +24,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "XY401000",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Insert",
     "dateOfBirth": "2002-04-27",
     "liabilityStartDate": "2025-08-19"

--- a/bruno/500 Requests/Insert/Trigger InternalServerError.bru
+++ b/bruno/500 Requests/Insert/Trigger InternalServerError.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "XY500000",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Insert",
     "dateOfBirth": "2002-04-27",
     "liabilityStartDate": "2025-08-19"

--- a/bruno/500 Requests/Terminate/Trigger HIP BadRequest.bru
+++ b/bruno/500 Requests/Terminate/Trigger HIP BadRequest.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "XY400000",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Terminate",
     "liabilityStartDate": "2025-08-19",
     "liabilityEndDate": "2026-06-30"

--- a/bruno/500 Requests/Terminate/Trigger HIP Unauthorized.bru
+++ b/bruno/500 Requests/Terminate/Trigger HIP Unauthorized.bru
@@ -24,7 +24,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "XY401000",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Terminate",
     "liabilityStartDate": "2025-08-19",
     "liabilityEndDate": "2026-06-30"

--- a/bruno/500 Requests/Terminate/Trigger InternalServerError.bru
+++ b/bruno/500 Requests/Terminate/Trigger InternalServerError.bru
@@ -23,7 +23,7 @@ headers {
 body:json {
   {
     "nationalInsuranceNumber": "XY500000",
-    "universalCreditRecordType": "{{universalCreditRecordType}}",
+    "universalCreditRecordType": "{{randomUniversalCreditRecordType}}",
     "universalCreditAction": "Terminate",
     "liabilityStartDate": "2025-08-19",
     "liabilityEndDate": "2026-06-30"

--- a/bruno/Auth/DEV-QA.bru
+++ b/bruno/Auth/DEV-QA.bru
@@ -24,22 +24,22 @@ script:pre-request {
   if (!['development', 'qa'].includes(bru.getEnvVar("ENVIRONMENT"))) {
     throw new Error('Environment must be set to Dev or QA');
   }
-
+  
   let TOTP;
   try {
     TOTP = require("totp-generator").TOTP;
   } catch (e) {
     throw new Error("Missing dependency: totp-generator\nRun 'npm install' in the collection folder. See README for details.");
   }
-
+  
   const totpSecret = bru.getEnvVar("TOTP_SECRET");
-
+  
   if (!totpSecret) {
     throw new Error("TOTP_SECRET not set in environment variables");
   }
-
+  
   const { otp } = await TOTP.generate(totpSecret, { digits: 8, algorithm: "SHA-512" });
-
+  
   bru.setEnvVar("totp", otp);
 }
 

--- a/bruno/collection.bru
+++ b/bruno/collection.bru
@@ -9,7 +9,7 @@ script:pre-request {
     bru.setEnvVar("invalidNino", randomInvalidNino);
 
     const randomUniversalCreditRecordType = helpers.randomUniversalCreditRecordType();
-    bru.setEnvVar("universalCreditRecordType", randomUniversalCreditRecordType);
+    bru.setEnvVar("randomUniversalCreditRecordType", randomUniversalCreditRecordType);
   }
 
   bru.setVar('correlationId', bru.interpolate('{{$guid}}'));

--- a/bruno/environments/1-Local.bru
+++ b/bruno/environments/1-Local.bru
@@ -1,9 +1,9 @@
 vars {
   ENVIRONMENT: local
   api-host: http://localhost:16107
+  govUkOriginatorId: TEST-GOV-UK-ORIGINATOR-ID
 }
 vars:secret [
-  govUkOriginatorId,
   authorization,
   nino,
   invalidNino

--- a/src/test/scala/uk/gov/hmrc/api/testData/BaseTestData.scala
+++ b/src/test/scala/uk/gov/hmrc/api/testData/BaseTestData.scala
@@ -23,6 +23,8 @@ import scala.util.matching.Regex
 
 trait BaseTestData {
 
+  val govUkOriginatorIdProvidedByDwp: String = "TEST-GOV-UK-ORIGINATOR-ID"
+
   private val NinoPattern: Regex =
     "^([ACEHJLMOPRSWXY][A-CEGHJ-NPR-TW-Z]|B[A-CEHJ-NPR-TW-Z]|G[ACEGHJ-NPR-TW-Z]|[KT][A-CEGHJ-MPR-TW-Z]|N[A-CEGHJL-NPR-SW-Z]|Z[A-CEGHJ-NPR-TW-Y])[0-9]{6}$".r
 
@@ -77,7 +79,7 @@ trait BaseTestData {
   def baseHeaders: Seq[(String, String)] = Seq(
     "Content-Type"         -> jsonContentType,
     "correlationId"        -> randomCorrelationId,
-    "gov-uk-originator-id" -> randomGovUkOriginatorId
+    "gov-uk-originator-id" -> govUkOriginatorIdProvidedByDwp
   )
 
   def invalidHeaders: Seq[(String, String)] = Seq(
@@ -91,7 +93,7 @@ trait BaseTestData {
     Seq(
       "Content-Type"         -> jsonContentType,
       "correlationId"        -> randomCorrelationId,
-      "gov-uk-originator-id" -> randomGovUkOriginatorId
+      "gov-uk-originator-id" -> govUkOriginatorIdProvidedByDwp
     )
 
   def removeHeader(headers: Seq[(String, String)], key: String): Seq[(String, String)] =


### PR DESCRIPTION
Changed Bruno request assertions to check for empty body for 404 responses.
Added expectedGovUkOriginatorId to match the one in stubs.

Depends on: https://github.com/hmrc/universal-credit-liability-api/pull/41