### PR TITLE
UCAPI-175: Updated the libraries and plugins to the latest versions message

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 3.10.2
+version = 3.10.6
 maxColumn = 120
 binPack.parentConstructors = false
 indent.callSite = 2

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 3.10.6
+version = 3.10.7
 maxColumn = 120
 binPack.parentConstructors = false
 indent.callSite = 2

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,7 @@
 import sbt.*
 
 object Dependencies {
-  val pekkoVersion = "1.2.0"
+  val pekkoVersion = "1.4.0"
 
   val test: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"            %% "api-test-runner"             % "0.10.0" % Test,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,19 +1,19 @@
 import sbt.*
 
 object Dependencies {
-  val pekkoVersion = "1.1.3"
+  val pekkoVersion = "1.2.0"
 
   val test: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"            %% "api-test-runner"             % "0.10.0" % Test,
-    "org.scalatestplus.play" %% "scalatestplus-play"          % "7.0.1"  % Test,
-    "org.playframework"      %% "play-ws"                     % "3.0.6"  % Test,
+    "org.scalatestplus.play" %% "scalatestplus-play"          % "7.0.2"  % Test,
+    "org.playframework"      %% "play-ws"                     % "3.0.9"  % Test,
     "org.apache.pekko"       %% "pekko-actor"                 % pekkoVersion,
     "org.apache.pekko"       %% "pekko-stream"                % pekkoVersion,
     "org.apache.pekko"       %% "pekko-protobuf-v3"           % pekkoVersion,
     "org.apache.pekko"       %% "pekko-actor-typed"           % pekkoVersion,
     "org.apache.pekko"       %% "pekko-serialization-jackson" % pekkoVersion,
     "org.apache.pekko"       %% "pekko-slf4j"                 % pekkoVersion,
-    "org.playframework"      %% "play-pekko-http-server"      % "3.0.6",
+    "org.playframework"      %% "play-pekko-http-server"      % "3.0.10",
     "uk.gov.hmrc"            %% "totp-generator"              % "1.0.0"  % Test
   )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   val test: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"            %% "api-test-runner"             % "0.10.0" % Test,
     "org.scalatestplus.play" %% "scalatestplus-play"          % "7.0.2"  % Test,
-    "org.playframework"      %% "play-ws"                     % "3.0.9"  % Test,
+    "org.playframework"      %% "play-ws"                     % "3.0.10" % Test,
     "org.apache.pekko"       %% "pekko-actor"                 % pekkoVersion,
     "org.apache.pekko"       %% "pekko-stream"                % pekkoVersion,
     "org.apache.pekko"       %% "pekko-protobuf-v3"           % pekkoVersion,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.11.7
+sbt.version=1.12.5

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.5
+sbt.version=1.12.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefact
   Resolver.ivyStylePatterns
 )
 
-addSbtPlugin("ch.epfl.scala"    % "sbt-scalafix"   % "0.14.5")
+addSbtPlugin("ch.epfl.scala"    % "sbt-scalafix"   % "0.14.6")
 addSbtPlugin("com.timushev.sbt" % "sbt-updates"    % "0.6.4")
 addSbtPlugin("org.scalameta"    % "sbt-scalafmt"   % "2.5.6")
 addSbtPlugin("uk.gov.hmrc"      % "sbt-auto-build" % "3.24.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefact
   Resolver.ivyStylePatterns
 )
 
-addSbtPlugin("ch.epfl.scala"    % "sbt-scalafix"   % "0.14.4")
+addSbtPlugin("ch.epfl.scala"    % "sbt-scalafix"   % "0.14.5")
 addSbtPlugin("com.timushev.sbt" % "sbt-updates"    % "0.6.4")
 addSbtPlugin("org.scalameta"    % "sbt-scalafmt"   % "2.5.6")
 addSbtPlugin("uk.gov.hmrc"      % "sbt-auto-build" % "3.24.0")


### PR DESCRIPTION
Updated sbt.version to `1.12.6`
Updated sbt-scalafix to `0.14.6`
Updated scalafmt to `3.10.7`
Updated pekkoVersion to `1.4.0`
Updated scalatestplus-play to `7.0.2`  
Updated play-ws to `3.0.10`
Updated play-pekko-http-server to `3.0.10`